### PR TITLE
Amendment to numpy-2 pr 6724

### DIFF
--- a/cirq-core/cirq/_compat.py
+++ b/cirq-core/cirq/_compat.py
@@ -193,7 +193,7 @@ def proper_repr(value: Any) -> str:
         return f"{value.__module__}.{value.__qualname__}"
 
     if isinstance(value, np.number):
-        return repr(value.item())
+        return str(value)
 
     return repr(value)
 

--- a/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate_test.py
+++ b/cirq-core/cirq/contrib/bayesian_network/bayesian_network_gate_test.py
@@ -57,10 +57,10 @@ def test_prob_encoding(input_prob):
     q = cirq.NamedQubit('q')
     gate = ccb.BayesianNetworkGate([('q', input_prob)], [])
     circuit = cirq.Circuit(gate.on(q))
-    simulate = cirq.Simulator().simulate
-    phi = simulate(circuit, qubit_order=[q], initial_state=0).state_vector(copy=True)
-
-    actual_probs = np.square(np.abs(phi, dtype=float)).tolist()
+    phi = (
+        cirq.Simulator().simulate(circuit, qubit_order=[q], initial_state=0).state_vector(copy=True)
+    )
+    actual_probs = [abs(x) ** 2 for x in phi]
 
     np.testing.assert_almost_equal(actual_probs[1], input_prob, decimal=4)
 
@@ -87,10 +87,9 @@ def test_initial_probs(p0, p1, p2, expected_probs, decompose):
     else:
         circuit = cirq.Circuit(gate.on(q0, q1, q2))
 
-    simulate = cirq.Simulator().simulate
-    result = simulate(circuit, qubit_order=[q0, q1, q2], initial_state=0).state_vector(copy=True)
+    result = cirq.Simulator().simulate(circuit, qubit_order=[q0, q1, q2], initial_state=0)
 
-    actual_probs = np.square(np.abs(result, dtype=np.float64)).tolist()
+    actual_probs = [abs(x) ** 2 for x in result.state_vector(copy=True)]
 
     np.testing.assert_allclose(actual_probs, expected_probs, atol=1e-6)
 
@@ -111,10 +110,10 @@ def test_arc_probs(input_prob_q0, input_prob_q1, expected_prob_q2, decompose):
     else:
         circuit = cirq.Circuit(gate.on(q0, q1, q2))
 
-    simulate = cirq.Simulator().simulate
-    result = simulate(circuit, qubit_order=[q0, q1, q2], initial_state=0).state_vector(copy=True)
+    result = cirq.Simulator().simulate(circuit, qubit_order=[q0, q1, q2], initial_state=0)
 
-    probs = np.square(np.abs(result, dtype=np.float64)).tolist()
+    probs = [abs(x) ** 2 for x in result.state_vector(copy=True)]
+
     actual_prob_q2_is_one = sum(probs[1::2])
 
     np.testing.assert_almost_equal(actual_prob_q2_is_one, expected_prob_q2, decimal=4)
@@ -135,10 +134,8 @@ def test_repro_figure_10_of_paper():
 
     qubits = [sp, sm, oi, ir]
     circuit = cirq.Circuit(cirq.decompose_once(gate.on(*qubits)))
-    simulate = cirq.Simulator().simulate
-    result = simulate(circuit, qubit_order=qubits, initial_state=0).state_vector(copy=True)
-
-    probs = np.square(np.abs(result, dtype=np.float64)).reshape((2, 2, 2, 2))
+    result = cirq.Simulator().simulate(circuit, qubit_order=qubits, initial_state=0)
+    probs = np.asarray([abs(x) ** 2 for x in result.state_vector(copy=True)]).reshape(2, 2, 2, 2)
 
     # p(IR = 0) = 0.7500
     np.testing.assert_almost_equal(np.sum(probs[0, :, :, :]), 0.7500, decimal=6)

--- a/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
+++ b/cirq-core/cirq/contrib/quantum_volume/quantum_volume.py
@@ -86,8 +86,7 @@ def compute_heavy_set(circuit: cirq.Circuit) -> List[int]:
     # The output wave function is a vector from the result value (big-endian) to
     # the probability of that bit-string. Return all of the bit-string
     # values that have a probability greater than the median.
-    results_vector = results.state_vector()
-    return [idx for idx, amp in enumerate(results_vector) if np.abs(np.square(amp)) > median]
+    return [idx for idx, amp in enumerate(results.state_vector()) if np.abs(amp**2) > median]
 
 
 @dataclass

--- a/cirq-core/cirq/devices/grid_qubit.py
+++ b/cirq-core/cirq/devices/grid_qubit.py
@@ -152,7 +152,7 @@ class _BaseGridQid(ops.Qid):
                 'Can only add integer tuples of length 2 to '
                 f'{type(self).__name__}. Instead was {other}'
             )
-        return self._with_row_col(row=self._row + int(other[0]), col=self._col + int(other[1]))
+        return self._with_row_col(row=self._row + other[0], col=self._col + other[1])
 
     def __sub__(self, other: Union[Tuple[int, int], Self]) -> Self:
         if isinstance(other, _BaseGridQid):
@@ -171,7 +171,7 @@ class _BaseGridQid(ops.Qid):
                 "Can only subtract integer tuples of length 2 to "
                 f"{type(self).__name__}. Instead was {other}"
             )
-        return self._with_row_col(row=self._row - int(other[0]), col=self._col - int(other[1]))
+        return self._with_row_col(row=self._row - other[0], col=self._col - other[1])
 
     def __radd__(self, other: Tuple[int, int]) -> Self:
         return self + other

--- a/cirq-core/cirq/experiments/fidelity_estimation.py
+++ b/cirq-core/cirq/experiments/fidelity_estimation.py
@@ -192,9 +192,7 @@ def xeb_fidelity(
         output_probabilities = state_vector_to_probabilities(output_state)
         bitstring_probabilities = output_probabilities[bitstrings].tolist()
     else:
-        bitstring_probabilities = [
-            np.abs(amplitudes[bitstring], dtype=float) ** 2 for bitstring in bitstrings
-        ]
+        bitstring_probabilities = [abs(amplitudes[bitstring]) ** 2 for bitstring in bitstrings]
     return estimator(dim, bitstring_probabilities)
 
 

--- a/cirq-core/cirq/linalg/transformations.py
+++ b/cirq-core/cirq/linalg/transformations.py
@@ -92,7 +92,7 @@ def match_global_phase(a: np.ndarray, b: np.ndarray) -> Tuple[np.ndarray, np.nda
         if r == 0:
             return 1j if i < 0 else -1j
 
-        return np.exp(-1j * complex(np.arctan2(i, r)), dtype=v.dtype)
+        return np.exp(-1j * np.arctan2(i, r))
 
     # Zero the phase at this entry in both matrices.
     return a * dephase(a[k]), b * dephase(b[k])
@@ -237,14 +237,13 @@ def _build_from_slices(
     """
     d = len(source.shape)
     out[...] = 0
-    dtype = source.flat[0].dtype
     for arg in args:
         source_slice: List[Any] = [slice(None)] * d
         target_slice: List[Any] = [slice(None)] * d
         for sleis in arg.slices:
             source_slice[sleis.axis] = sleis.source_index
             target_slice[sleis.axis] = sleis.target_index
-        out[tuple(target_slice)] += dtype.type(arg.scale) * source[tuple(source_slice)]
+        out[tuple(target_slice)] += arg.scale * source[tuple(source_slice)]
     return out
 
 
@@ -565,9 +564,7 @@ def sub_state_vector(
     best_candidate = max(candidates, key=lambda c: float(np.linalg.norm(c, 2)))
     best_candidate = best_candidate / np.linalg.norm(best_candidate)
     left = np.conj(best_candidate.reshape((keep_dims,))).T
-    coherence_measure = sum(
-        [np.abs(np.dot(left, c.reshape((keep_dims,))), dtype=float) ** 2 for c in candidates]
-    )
+    coherence_measure = sum([abs(np.dot(left, c.reshape((keep_dims,)))) ** 2 for c in candidates])
 
     if protocols.approx_eq(coherence_measure, 1, atol=atol):
         return np.exp(2j * np.pi * np.random.random()) * best_candidate.reshape(ret_shape)

--- a/cirq-core/cirq/ops/clifford_gate.py
+++ b/cirq-core/cirq/ops/clifford_gate.py
@@ -673,7 +673,7 @@ class SingleQubitCliffordGate(CliffordGate):
             to = x_to * z_to  # Y = iXZ
             to._coefficient *= 1j
         # pauli_mask returns a value between 0 and 4 for [I, X, Y, Z].
-        to_gate = Pauli._XYZ[to.pauli_mask[0] - np.uint8(1)]
+        to_gate = Pauli._XYZ[to.pauli_mask[0] - 1]
         return (to_gate, bool(to.coefficient != 1.0))
 
     def dense_pauli_string(self, pauli: Pauli) -> 'cirq.DensePauliString':

--- a/cirq-core/cirq/ops/dense_pauli_string.py
+++ b/cirq-core/cirq/ops/dense_pauli_string.py
@@ -277,7 +277,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
         if split is not None:
             p, i = split
             mask = np.copy(self.pauli_mask)
-            mask[i] ^= np.int64(p)
+            mask[i] ^= p
             return concrete_class(
                 pauli_mask=mask,
                 coefficient=self.coefficient * _vectorized_pauli_mul_phase(self.pauli_mask[i], p),
@@ -293,7 +293,7 @@ class BaseDensePauliString(raw_types.Gate, metaclass=abc.ABCMeta):
         if split is not None:
             p, i = split
             mask = np.copy(self.pauli_mask)
-            mask[i] ^= np.int64(p)
+            mask[i] ^= p
             return type(self)(
                 pauli_mask=mask,
                 coefficient=self.coefficient * _vectorized_pauli_mul_phase(p, self.pauli_mask[i]),
@@ -552,7 +552,7 @@ class MutableDensePauliString(BaseDensePauliString):
         if split is not None:
             p, i = split
             self._coefficient *= _vectorized_pauli_mul_phase(self.pauli_mask[i], p)
-            self.pauli_mask[i] ^= np.int64(p)
+            self.pauli_mask[i] ^= p
             return self
 
         return NotImplemented

--- a/cirq-core/cirq/ops/fourier_transform.py
+++ b/cirq-core/cirq/ops/fourier_transform.py
@@ -138,10 +138,9 @@ class PhaseGradientGate(raw_types.Gate):
             return NotImplemented
 
         n = int(np.prod([args.target_tensor.shape[k] for k in args.axes], dtype=np.int64))
-        dtype = args.target_tensor.flat[0].dtype
         for i in range(n):
             p = 1j ** (4 * i / n * self.exponent)
-            args.target_tensor[args.subspace_index(big_endian_bits_int=i)] *= dtype.type(p)
+            args.target_tensor[args.subspace_index(big_endian_bits_int=i)] *= p
 
         return args.target_tensor
 

--- a/cirq-core/cirq/ops/fsim_gate.py
+++ b/cirq-core/cirq/ops/fsim_gate.py
@@ -23,7 +23,7 @@ applies more generally to fermions, thus the name of the gate.
 
 import cmath
 import math
-from typing import AbstractSet, Any, Dict, Iterator, Optional, Tuple, Union
+from typing import AbstractSet, Any, Dict, Iterator, Optional, Tuple
 
 import numpy as np
 import sympy
@@ -50,12 +50,6 @@ def _zero_mod_pi(param: 'cirq.TParamVal') -> bool:
 def _half_pi_mod_pi(param: 'cirq.TParamVal') -> bool:
     """Returns True iff param, assumed to be in [-pi, pi), is pi/2 (mod pi)."""
     return param in (-np.pi / 2, np.pi / 2, -sympy.pi / 2, sympy.pi / 2)
-
-
-def _plainvalue(value: Union[int, float, complex, np.number]) -> Union[int, float, complex]:
-    """Returns a plain Python number if the given value is a NumPy number.
-    Used to avoid a change in repr behavior introduced in NumPy 2."""
-    return value.item() if isinstance(value, np.number) else value
 
 
 @value.value_equality(approximate=True)
@@ -202,8 +196,8 @@ class FSimGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
         yield cirq.CZ(a, b) ** (-self.phi / np.pi)
 
     def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs') -> Tuple[str, ...]:
-        t = args.format_radians(_plainvalue(self.theta))
-        p = args.format_radians(_plainvalue(self.phi))
+        t = args.format_radians(self.theta)
+        p = args.format_radians(self.phi)
         return f'FSim({t}, {p})', f'FSim({t}, {p})'
 
     def __pow__(self, power) -> 'FSimGate':
@@ -482,11 +476,11 @@ class PhasedFSimGate(gate_features.InterchangeableQubitsGate, raw_types.Gate):
         yield cirq.Z(q1) ** to_exponent(after[1])
 
     def _circuit_diagram_info_(self, args: 'cirq.CircuitDiagramInfoArgs') -> Tuple[str, ...]:
-        theta = args.format_radians(_plainvalue(self.theta))
-        zeta = args.format_radians(_plainvalue(self.zeta))
-        chi = args.format_radians(_plainvalue(self.chi))
-        gamma = args.format_radians(_plainvalue(self.gamma))
-        phi = args.format_radians(_plainvalue(self.phi))
+        theta = args.format_radians(self.theta)
+        zeta = args.format_radians(self.zeta)
+        chi = args.format_radians(self.chi)
+        gamma = args.format_radians(self.gamma)
+        phi = args.format_radians(self.phi)
         return (
             f'PhFSim({theta}, {zeta}, {chi}, {gamma}, {phi})',
             f'PhFSim({theta}, {zeta}, {chi}, {gamma}, {phi})',

--- a/cirq-core/cirq/ops/parity_gates.py
+++ b/cirq-core/cirq/ops/parity_gates.py
@@ -335,8 +335,7 @@ class ZZPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate):
         if global_phase != 1:
             args.target_tensor *= global_phase
 
-        dtype = args.target_tensor.flat[0].dtype
-        relative_phase = dtype.type(1j ** (2 * self.exponent))
+        relative_phase = 1j ** (2 * self.exponent)
         zo = args.subspace_index(0b01)
         oz = args.subspace_index(0b10)
         args.target_tensor[oz] *= relative_phase

--- a/cirq-core/cirq/ops/pauli_string.py
+++ b/cirq-core/cirq/ops/pauli_string.py
@@ -740,7 +740,7 @@ class PauliString(raw_types.Operation, Generic[TKey]):
         while any(result.shape):
             result = np.trace(result, axis1=0, axis2=len(result.shape) // 2)
 
-        return float(np.real(result * result.dtype.type(self.coefficient)))
+        return float(np.real(result * self.coefficient))
 
     def zip_items(
         self, other: 'cirq.PauliString[TKey]'

--- a/cirq-core/cirq/ops/pauli_string_test.py
+++ b/cirq-core/cirq/ops/pauli_string_test.py
@@ -980,7 +980,7 @@ def test_expectation_from_state_vector_invalid_input():
     rho_or_wf = 0.5 * np.ones((2, 2), dtype=np.complex64)
     _ = ps.expectation_from_state_vector(rho_or_wf, q_map)
 
-    wf = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16, dtype=np.complex64))
+    wf = np.arange(16, dtype=np.complex64) / np.linalg.norm(np.arange(16))
     with pytest.raises(ValueError, match='shape'):
         ps.expectation_from_state_vector(wf.reshape((16, 1)), q_map_2)
     with pytest.raises(ValueError, match='shape'):

--- a/cirq-core/cirq/ops/swap_gates.py
+++ b/cirq-core/cirq/ops/swap_gates.py
@@ -244,8 +244,8 @@ class ISwapPowGate(gate_features.InterchangeableQubitsGate, eigen_gate.EigenGate
         args.available_buffer[zo] = args.target_tensor[zo]
         args.target_tensor[zo] = args.target_tensor[oz]
         args.target_tensor[oz] = args.available_buffer[zo]
-        args.target_tensor[zo] *= args.target_tensor[zo].dtype.type(1j)
-        args.target_tensor[oz] *= args.target_tensor[oz].dtype.type(1j)
+        args.target_tensor[zo] *= 1j
+        args.target_tensor[oz] *= 1j
         p = 1j ** (2 * self._exponent * self._global_shift)
         if p != 1:
             args.target_tensor *= p

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol.py
@@ -245,8 +245,6 @@ class CircuitDiagramInfoArgs:
     def format_real(self, val: Union[sympy.Basic, int, float]) -> str:
         if isinstance(val, sympy.Basic):
             return str(val)
-        if isinstance(val, np.number):
-            val = val.item()
         if val == int(val):
             return str(int(val))
         if self.precision is None:
@@ -279,6 +277,8 @@ class CircuitDiagramInfoArgs:
         if self.precision is not None and not isinstance(radians, sympy.Basic):
             quantity = self.format_real(radians / np.pi)
             return quantity + unit
+        if isinstance(radians, np.number):
+            return str(radians)
         return repr(radians)
 
     def copy(self):

--- a/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
+++ b/cirq-core/cirq/protocols/circuit_diagram_info_protocol_test.py
@@ -255,6 +255,7 @@ def test_format_radians_without_precision():
     assert args.format_radians(-np.pi) == '-pi'
     assert args.format_radians(1.1) == '1.1'
     assert args.format_radians(1.234567) == '1.234567'
+    assert args.format_radians(np.float32(1.234567)) == '1.234567'
     assert args.format_radians(1 / 7) == repr(1 / 7)
     assert args.format_radians(sympy.Symbol('t')) == 't'
     assert args.format_radians(sympy.Symbol('t') * 2 + 1) == '2*t + 1'
@@ -264,6 +265,7 @@ def test_format_radians_without_precision():
     assert args.format_radians(-np.pi) == '-π'
     assert args.format_radians(1.1) == '1.1'
     assert args.format_radians(1.234567) == '1.234567'
+    assert args.format_radians(np.float32(1.234567)) == '1.234567'
     assert args.format_radians(1 / 7) == repr(1 / 7)
     assert args.format_radians(sympy.Symbol('t')) == 't'
     assert args.format_radians(sympy.Symbol('t') * 2 + 1) == '2*t + 1'

--- a/cirq-core/cirq/protocols/json_serialization_test.py
+++ b/cirq-core/cirq/protocols/json_serialization_test.py
@@ -55,6 +55,13 @@ TESTED_MODULES: Dict[str, Optional[_ModuleDeprecation]] = {
     'non_existent_should_be_fine': None,
 }
 
+# TODO(#6706) remove after cirq_rigetti supports NumPy 2.0
+if np.__version__.startswith("2."):  # pragma: no cover
+    warnings.warn(
+        "json_serialization_test - ignoring cirq_rigetti due to incompatibility with NumPy 2.0"
+    )
+    del TESTED_MODULES["cirq_rigetti"]
+
 
 def _get_testspecs_for_modules() -> List[ModuleJsonTestSpec]:
     modules = []

--- a/cirq-core/cirq/qis/measures.py
+++ b/cirq-core/cirq/qis/measures.py
@@ -234,7 +234,7 @@ def _numpy_arrays_to_state_vectors_or_density_matrices(
 def _fidelity_state_vectors_or_density_matrices(state1: np.ndarray, state2: np.ndarray) -> float:
     if state1.ndim == 1 and state2.ndim == 1:
         # Both state vectors
-        return np.abs(np.vdot(state1, state2), dtype=float) ** 2
+        return np.abs(np.vdot(state1, state2)) ** 2
     elif state1.ndim == 1 and state2.ndim == 2:
         # state1 is a state vector and state2 is a density matrix
         return np.real(np.conjugate(state1) @ state2 @ state1)
@@ -245,7 +245,7 @@ def _fidelity_state_vectors_or_density_matrices(state1: np.ndarray, state2: np.n
         # Both density matrices
         state1_sqrt = _sqrt_positive_semidefinite_matrix(state1)
         eigs = linalg.eigvalsh(state1_sqrt @ state2 @ state1_sqrt)
-        trace = np.sum(np.sqrt(np.abs(eigs, dtype=float)))
+        trace = np.sum(np.sqrt(np.abs(eigs)))
         return trace**2
     raise ValueError(
         'The given arrays must be one- or two-dimensional. '

--- a/cirq-core/cirq/qis/states.py
+++ b/cirq-core/cirq/qis/states.py
@@ -609,8 +609,8 @@ def bloch_vector_from_state_vector(
     """
     rho = density_matrix_from_state_vector(state_vector, [index], qid_shape=qid_shape)
     v = np.zeros(3, dtype=np.float32)
-    v[0] = np.float32(2) * np.real(rho[0][1])
-    v[1] = np.float32(2) * np.imag(rho[1][0])
+    v[0] = 2 * np.real(rho[0][1])
+    v[1] = 2 * np.imag(rho[1][0])
     v[2] = np.real(rho[0][0] - rho[1][1])
 
     return v
@@ -738,9 +738,7 @@ def dirac_notation(
     ket = "|{}⟩"
     for x in range(len(perm_list)):
         format_str = "({:." + str(decimals) + "g})"
-        val = round(state_vector[x].real, decimals) + np.complex128(1j) * round(
-            state_vector[x].imag, decimals
-        )
+        val = round(state_vector[x].real, decimals) + 1j * round(state_vector[x].imag, decimals)
 
         if round(val.real, decimals) == 0 and round(val.imag, decimals) != 0:
             val = val.imag

--- a/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
+++ b/cirq-core/cirq/sim/clifford/clifford_simulator_test.py
@@ -23,7 +23,7 @@ def test_run_no_repetitions():
     simulator = cirq.CliffordSimulator()
     circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=0)
-    assert sum(result.measurements['q(0)'].astype(np.uint16)) == 0
+    assert sum(result.measurements['q(0)']) == 0
 
 
 def test_run_hadamard():
@@ -31,8 +31,8 @@ def test_run_hadamard():
     simulator = cirq.CliffordSimulator()
     circuit = cirq.Circuit(cirq.H(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] < 80
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] > 20
+    assert sum(result.measurements['q(0)'])[0] < 80
+    assert sum(result.measurements['q(0)'])[0] > 20
 
 
 def test_run_GHZ():
@@ -40,8 +40,8 @@ def test_run_GHZ():
     simulator = cirq.CliffordSimulator()
     circuit = cirq.Circuit(cirq.H(q0), cirq.H(q1), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] < 80
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] > 20
+    assert sum(result.measurements['q(0)'])[0] < 80
+    assert sum(result.measurements['q(0)'])[0] > 20
 
 
 def test_run_correlations():
@@ -392,8 +392,8 @@ def test_clifford_circuit_2(qubits, split):
     circuit.append(cirq.measure(qubits[0]))
     result = cirq.CliffordSimulator(split_untangled_states=split).run(circuit, repetitions=100)
 
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] < 80
-    assert sum(result.measurements['q(0)'].astype(np.uint16))[0] > 20
+    assert sum(result.measurements['q(0)'])[0] < 80
+    assert sum(result.measurements['q(0)'])[0] > 20
 
 
 @pytest.mark.parametrize('split', [True, False])

--- a/cirq-core/cirq/sim/simulator.py
+++ b/cirq-core/cirq/sim/simulator.py
@@ -912,7 +912,7 @@ class SimulationTrialResult(Generic[TSimulatorState]):
     def __str__(self) -> str:
         def bitstring(vals):
             separator = ' ' if np.max(vals) >= 10 else ''
-            return separator.join(str(int(v.item())) for v in vals)
+            return separator.join(str(v.item()) for v in vals)
 
         results = sorted([(key, bitstring(val)) for key, val in self.measurements.items()])
         if not results:

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -115,7 +115,7 @@ def test_run_repetitions_terminal_measurement_stochastic():
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.H(q), cirq.measure(q, key='q'))
     results = cirq.Simulator().run(c, repetitions=10000)
-    assert 1000 <= sum(v[0] for v in results.measurements['q']) < 9000
+    assert 1000 <= np.count_nonzero(results.measurements['q']) < 9000
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
@@ -255,7 +255,7 @@ def test_run_mixture(dtype: Type[np.complexfloating], split: bool):
     simulator = cirq.Simulator(dtype=dtype, split_untangled_states=split)
     circuit = cirq.Circuit(cirq.bit_flip(0.5)(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert 20 < sum(result.measurements['q(0)'])[0] < 80
+    assert 20 < np.count_nonzero(result.measurements['q(0)']) < 80
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
@@ -265,8 +265,8 @@ def test_run_mixture_with_gates(dtype: Type[np.complexfloating], split: bool):
     simulator = cirq.Simulator(dtype=dtype, split_untangled_states=split, seed=23)
     circuit = cirq.Circuit(cirq.H(q0), cirq.phase_flip(0.5)(q0), cirq.H(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert sum(result.measurements['q(0)'])[0] < 80
-    assert sum(result.measurements['q(0)'])[0] > 20
+    assert np.count_nonzero(result.measurements['q(0)']) < 80
+    assert np.count_nonzero(result.measurements['q(0)']) > 20
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])

--- a/cirq-core/cirq/sim/sparse_simulator_test.py
+++ b/cirq-core/cirq/sim/sparse_simulator_test.py
@@ -115,7 +115,7 @@ def test_run_repetitions_terminal_measurement_stochastic():
     q = cirq.LineQubit(0)
     c = cirq.Circuit(cirq.H(q), cirq.measure(q, key='q'))
     results = cirq.Simulator().run(c, repetitions=10000)
-    assert 1000 <= sum(np.int64(v[0]) for v in results.measurements['q']) < 9000
+    assert 1000 <= sum(v[0] for v in results.measurements['q']) < 9000
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
@@ -255,7 +255,7 @@ def test_run_mixture(dtype: Type[np.complexfloating], split: bool):
     simulator = cirq.Simulator(dtype=dtype, split_untangled_states=split)
     circuit = cirq.Circuit(cirq.bit_flip(0.5)(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert 20 < sum(result.measurements['q(0)'].astype(np.uint16)) < 80
+    assert 20 < sum(result.measurements['q(0)'])[0] < 80
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
@@ -265,8 +265,8 @@ def test_run_mixture_with_gates(dtype: Type[np.complexfloating], split: bool):
     simulator = cirq.Simulator(dtype=dtype, split_untangled_states=split, seed=23)
     circuit = cirq.Circuit(cirq.H(q0), cirq.phase_flip(0.5)(q0), cirq.H(q0), cirq.measure(q0))
     result = simulator.run(circuit, repetitions=100)
-    assert sum(result.measurements['q(0)'].astype(np.uint16)) < 80
-    assert sum(result.measurements['q(0)'].astype(np.uint16)) > 20
+    assert sum(result.measurements['q(0)'])[0] < 80
+    assert sum(result.measurements['q(0)'])[0] > 20
 
 
 @pytest.mark.parametrize('dtype', [np.complex64, np.complex128])
@@ -1385,7 +1385,7 @@ def test_noise_model():
     simulator = cirq.Simulator(noise=noise_model)
     result = simulator.run(circuit, repetitions=100)
 
-    assert 20 <= sum(result.measurements['q(0)'].astype(np.uint16))[0] < 80
+    assert 20 <= sum(result.measurements['q(0)'])[0] < 80
 
 
 def test_separated_states_str_does_not_merge():

--- a/cirq-core/cirq/sim/state_vector_simulation_state.py
+++ b/cirq-core/cirq/sim/state_vector_simulation_state.py
@@ -230,7 +230,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
 
         for index in range(len(kraus_tensors)):
             prepare_into_buffer(index)
-            weight = float(np.linalg.norm(self._buffer)) ** 2
+            weight = float(np.linalg.norm(self._buffer) ** 2)
 
             if weight > fallback_weight:
                 fallback_weight_index = index
@@ -248,7 +248,7 @@ class _BufferedStateVector(qis.QuantumStateRepresentation):
             weight = fallback_weight
             index = fallback_weight_index
 
-        self._buffer /= np.sqrt(weight, dtype=self._buffer.dtype)
+        self._buffer /= np.sqrt(weight)
         self._swap_target_tensor_for(self._buffer)
         return index
 

--- a/cirq-core/cirq/sim/state_vector_simulator.py
+++ b/cirq-core/cirq/sim/state_vector_simulator.py
@@ -127,22 +127,17 @@ class StateVectorTrialResult(
     def final_state_vector(self) -> np.ndarray:
         ret = self._get_merged_sim_state().target_tensor.reshape(-1)
         norm = np.linalg.norm(ret)
-        diff = abs(norm - norm.dtype.type(1))
-        abs_tol = np.sqrt(np.finfo(ret.dtype).eps)
-        if diff > abs_tol:
+        if abs(norm - 1) > np.sqrt(np.finfo(ret.dtype).eps):
             warnings.warn(
-                f"Final state vector's norm = {norm} is too far from 1."
-                f" (Difference = {diff} > {abs_tol}.) "
-                "Skipping renormalization."
+                f"final state vector's {norm=} is too far from 1,"
+                f" {abs(norm-1)} > {np.sqrt(np.finfo(ret.dtype).eps)}."
+                "skipping renormalization"
             )
             return ret
-        # Normalize only if doing so improves the round-off on total probability.
-        ret_normed = ret / norm
-        dotprod = np.vdot(ret, ret)
-        normed_dotprod = np.vdot(ret_normed, ret_normed)
-        one = ret.flat[0].dtype.type(1)
-        round_off_change = abs(normed_dotprod - one) - abs(dotprod - one)
-        result = ret_normed if round_off_change < 0 else ret
+        # normalize only if doing so improves the round-off on total probability
+        ret_norm = ret / norm
+        round_off_change = abs(np.vdot(ret_norm, ret_norm) - 1) - abs(np.vdot(ret, ret) - 1)
+        result = ret_norm if round_off_change < 0 else ret
         return result
 
     def state_vector(self, copy: bool = False) -> np.ndarray:
@@ -182,7 +177,6 @@ class StateVectorTrialResult(
 
     def _value_equality_values_(self):
         measurements = {k: v.tolist() for k, v in sorted(self.measurements.items())}
-
         return self.params, measurements, self.qubit_map, self.final_state_vector.tolist()
 
     def __str__(self) -> str:

--- a/cirq-core/cirq/testing/circuit_compare_test.py
+++ b/cirq-core/cirq/testing/circuit_compare_test.py
@@ -418,8 +418,7 @@ def test_assert_has_consistent_apply_unitary():
 
         def _apply_unitary_(self, args: cirq.ApplyUnitaryArgs) -> np.ndarray:
             i = args.subspace_index(1)
-            dtype = args.target_tensor[i].dtype
-            args.target_tensor[i] *= dtype.type(self.power) * dtype.type(2)
+            args.target_tensor[i] *= self.power * 2
             return args.target_tensor
 
         def _unitary_(self):

--- a/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation.py
+++ b/cirq-core/cirq/transformers/analytical_decompositions/two_qubit_state_preparation.py
@@ -63,9 +63,7 @@ def prepare_two_qubit_state_using_sqrt_iswap(
     if np.isclose(s[0], 1):
         # Product state can be prepare with just single qubit unitaries.
         return _1q_matrices_to_ops(u, vh.T, q0, q1, True)
-    alpha = np.arccos(
-        np.sqrt(np.clip(np.float64(1) - s[0] * np.float64(2) * s[1], 0, 1)), dtype=np.float64
-    )
+    alpha = np.arccos(np.sqrt(np.clip(1 - s[0] * 2 * s[1], 0, 1)))
     sqrt_iswap_gate = ops.SQRT_ISWAP_INV if use_sqrt_iswap_inv else ops.SQRT_ISWAP
     op_list = [ops.ry(2 * alpha).on(q0), sqrt_iswap_gate.on(q0, q1)]
     intermediate_state = circuits.Circuit(op_list).final_state_vector(
@@ -100,9 +98,9 @@ def prepare_two_qubit_state_using_cz(
         # Product state can be prepare with just single qubit unitaries.
         return _1q_matrices_to_ops(u, vh.T, q0, q1, True)
     alpha = np.arccos(np.clip(s[0], 0, 1))
-    op_list = [ops.ry(np.float64(2) * alpha).on(q0), ops.H.on(q1), ops.CZ.on(q0, q1)]
+    op_list = [ops.ry(2 * alpha).on(q0), ops.H.on(q1), ops.CZ.on(q0, q1)]
     intermediate_state = circuits.Circuit(op_list).final_state_vector(
-        ignore_terminal_measurements=False, dtype=np.complex128
+        ignore_terminal_measurements=False, dtype=np.complex64
     )
     u_CZ, _, vh_CZ = np.linalg.svd(intermediate_state.reshape(2, 2))
     return op_list + _1q_matrices_to_ops(
@@ -135,7 +133,7 @@ def prepare_two_qubit_state_using_iswap(
         return _1q_matrices_to_ops(u, vh.T, q0, q1, True)
     alpha = np.arccos(np.clip(s[0], 0, 1))
     op_list = [
-        ops.ry(np.float64(2) * alpha).on(q0),
+        ops.ry(2 * alpha).on(q0),
         ops.H.on(q1),
         ops.ISWAP_INV.on(q0, q1) if use_iswap_inv else ops.ISWAP.on(q0, q1),
     ]

--- a/cirq-core/cirq/value/digits.py
+++ b/cirq-core/cirq/value/digits.py
@@ -113,8 +113,8 @@ def big_endian_digits_to_int(digits: Iterable[int], *, base: Union[int, Iterable
     for d, b in zip(digits, base):
         if not (0 <= d < b):
             raise ValueError(f'Out of range digit. Digit: {d!r}, base: {b!r}')
-        result *= int(b)
-        result += int(d)
+        result *= b
+        result += d
     return result
 
 

--- a/cirq-core/requirements.txt
+++ b/cirq-core/requirements.txt
@@ -4,10 +4,10 @@ attrs>=21.3.0
 duet>=0.2.8
 matplotlib~=3.0
 networkx>=2.4
-numpy>=1.25
+numpy>=1.24
 pandas
 sortedcontainers~=2.0
-scipy~=1.1
+scipy~=1.8
 sympy
 typing_extensions>=4.2
 tqdm

--- a/cirq-google/cirq_google/serialization/arg_func_langs.py
+++ b/cirq-google/cirq_google/serialization/arg_func_langs.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import builtins
 import math
 import numbers
 from typing import cast, Dict, FrozenSet, Iterable, Iterator, List, Optional, Sequence, Union
@@ -475,9 +474,9 @@ def clifford_tableau_arg_to_proto(
     msg = v2.program_pb2.CliffordTableau() if out is None else out
     msg.num_qubits = value.n
     msg.initial_state = value.initial_state
-    msg.xs.extend(map(builtins.bool, value.xs.flatten()))
-    msg.rs.extend(map(builtins.bool, value.rs.flatten()))
-    msg.zs.extend(map(builtins.bool, value.zs.flatten()))
+    msg.xs.extend(map(bool, value.xs.flatten()))
+    msg.rs.extend(map(bool, value.rs.flatten()))
+    msg.zs.extend(map(bool, value.zs.flatten()))
     return msg
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,13 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_configure(config):
+    # If requested, globally enable verbose NumPy 2 warnings about data type
+    # promotion. See https://numpy.org/doc/2.0/numpy_2_0_migration_guide.html.
+    if config.option.warn_numpy_data_promotion:
+        np._set_promotion_state("weak_and_warn")
+
+
 def pytest_collection_modifyitems(config, items):
     # Let pytest handle markexpr if present.  Make an exception for
     # `pytest --co -m skip` so we can check test skipping rules below.
@@ -54,11 +61,6 @@ def pytest_collection_modifyitems(config, items):
     if config.option.enable_slow_tests:
         del skip_marks["slow"]  # pragma: no cover
     skip_keywords = frozenset(skip_marks.keys())
-
-    # If requested, globally enable verbose NumPy 2 warnings about data type
-    # promotion. See https://numpy.org/doc/2.0/numpy_2_0_migration_guide.html.
-    if config.option.warn_numpy_data_promotion:
-        np._set_promotion_state("weak_and_warn")
 
     for item in items:
         for k in skip_keywords.intersection(item.keywords):

--- a/dev_tools/requirements/dev-np2.env.txt
+++ b/dev_tools/requirements/dev-np2.env.txt
@@ -1,0 +1,17 @@
+# This file describes a development environment for cirq with NumPy-2
+# It skips cirq_rigetti which has dependencies incompatible with NumPy-2.
+#
+# TODO(#6706) remove this file after cirq_rigetti supports NumPy 2.0
+
+# dev.env.txt expanded without cirq-rigetti ----------------------------------
+
+-r ../../cirq-aqt/requirements.txt
+-r ../../cirq-core/requirements.txt
+-r ../../cirq-google/requirements.txt
+-r ../../cirq-core/cirq/contrib/requirements.txt
+
+-r deps/dev-tools.txt
+
+# own rules ------------------------------------------------------------------
+
+numpy>=2

--- a/examples/bb84.py
+++ b/examples/bb84.py
@@ -128,7 +128,7 @@ def main(num_qubits=8):
     repetitions = 1
 
     result = cirq.Simulator().run(program=circuit, repetitions=repetitions)
-    result_bitstring = bitstring([int(result.measurements[str(q)][0].item()) for q in qubits])
+    result_bitstring = bitstring([result.measurements[str(q)].item() for q in qubits])
 
     # Take only qubits where bases match
     obtained_key = ''.join(
@@ -158,14 +158,14 @@ def main(num_qubits=8):
     # Run simulations.
     repetitions = 1
     result = cirq.Simulator().run(program=alice_eve_circuit, repetitions=repetitions)
-    eve_state = [int(result.measurements[str(q)][0].item()) for q in qubits]
+    eve_state = [result.measurements[str(q)].item() for q in qubits]
 
     eve_bob_circuit = make_bb84_circ(num_qubits, eve_basis, bob_basis, eve_state)
 
     # Run simulations.
     repetitions = 1
     result = cirq.Simulator().run(program=eve_bob_circuit, repetitions=repetitions)
-    result_bitstring = bitstring([int(result.measurements[str(q)][0].item()) for q in qubits])
+    result_bitstring = bitstring([result.measurements[str(q)].item() for q in qubits])
 
     # Take only qubits where bases match
     obtained_key = ''.join(

--- a/examples/stabilizer_code.py
+++ b/examples/stabilizer_code.py
@@ -35,7 +35,7 @@ def _build_by_code(mat: np.ndarray) -> List[str]:
     for i in range(mat.shape[0]):
         ps = ''
         for j in range(n):
-            k = np.int8(2) * mat[i, j + n] + mat[i, j]
+            k = 2 * mat[i, j + n] + mat[i, j]
             ps += "IXZY"[k]
         out.append(ps)
     return out


### PR DESCRIPTION
- simplify `format_radians` code
- restore numpy casting as in main, but ensure all tests pass
- exclude cirq_rigetti from json_serialization_test when using numpy-2
- add temporary requirements file for np2 development environment