### PR TITLE
Add "set -e" inside command substitutions

### DIFF
--- a/dev_tools/packaging/produce-package.sh
+++ b/dev_tools/packaging/produce-package.sh
@@ -58,14 +58,14 @@ echo "Creating pristine repository clone at ${tmp_git_dir}"
 git clone --shared --quiet "${repo_dir}" "${tmp_git_dir}"
 cd "${tmp_git_dir}"
 if [ -n "${SPECIFIED_VERSION}" ]; then
-    CURRENT_VERSION=$(my_dev_tools_modules print_version)
+    CURRENT_VERSION=$(set -e; my_dev_tools_modules print_version)
     my_dev_tools_modules replace_version --old="${CURRENT_VERSION}" --new="${SPECIFIED_VERSION}"
 fi
 
 # Python 3 wheel.
 echo "Producing python 3 package files."
 
-CIRQ_MODULES=$(my_dev_tools_modules list --mode folder --include-parent)
+CIRQ_MODULES=$(set -e; my_dev_tools_modules list --mode folder --include-parent)
 
 for m in $CIRQ_MODULES; do
   echo "processing $m/setup.py..."


### PR DESCRIPTION
With the new `.shellcheckrc` proposed in PR #7079, `shellcheck` warns
about a couple of places here where `set -e` is implicitly disabled.
It seems better to address them, and it's easy, so here we are.

```text
In dev_tools/packaging/produce-package.sh line 61:
    CURRENT_VERSION=$(my_dev_tools_modules print_version)
                      ^------------------^ SC2311 (info): Bash implicitly
disabled set -e for this function invocation because it's inside a
command substitution. Add set -e; before it or enable inherit_errexit.

In dev_tools/packaging/produce-package.sh line 68:
CIRQ_MODULES=$(my_dev_tools_modules list --mode folder --include-parent)
               ^------------------^ SC2311 (info): Bash implicitly disabled
set -e for this function invocation because it's inside a command
substitution. Add set -e; before it or enable inherit_errexit.

For more information:
  https://www.shellcheck.net/wiki/SC2311 -- Bash implicitly disabled
  set -e f...
```
